### PR TITLE
feat: add GitHub Actions workflow for Storybook PR previews

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,4 +1,4 @@
-# Deploy Storybook previews for pull requests
+# Deploy Storybook previews for pull requests using hybrid approach
 name: Deploy PR Preview
 
 on:
@@ -6,10 +6,12 @@ on:
     types: [opened, reopened, synchronize, closed]
 
 # Prevent multiple concurrent deployments for the same PR
-concurrency: preview-${{ github.ref }}
+concurrency: 
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
   pull-requests: write
@@ -17,6 +19,10 @@ permissions:
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}pr-preview/pr-${{ github.event.number }}/
+    if: github.event.action != 'closed'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,25 +31,47 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24.2.0'
-        if: github.event.action != 'closed'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 10
-        if: github.event.action != 'closed'
 
       - name: Install dependencies
         run: pnpm install
-        if: github.event.action != 'closed'
 
       - name: Build Storybook
         run: pnpm build-storybook
-        if: github.event.action != 'closed'
 
-      - name: Deploy PR Preview
+      # Use the pr-preview-action to handle the branch deployment
+      - name: Deploy PR Preview to gh-pages branch
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: storybook-static
           preview-branch: gh-pages
           umbrella-dir: pr-preview
+
+      # Also create an artifact for backup/manual download
+      - name: Upload Storybook artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: storybook-preview-pr-${{ github.event.number }}
+          path: storybook-static
+          retention-days: 7
+
+  cleanup-preview:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'closed'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Clean up PR Preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: storybook-static
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: remove


### PR DESCRIPTION
Add automated PR preview deployment using rossjrw/pr-preview-action:
- Creates preview deployments for opened/updated PRs
- Automatically comments on PRs with preview links
- Cleans up previews when PRs are closed
- Preview URLs: https://[owner].github.io/[repo]/pr-preview/pr-[number]/

🤖 Generated with [Claude Code](https://claude.ai/code)